### PR TITLE
fix: parser version checks on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /oklch-color-picker
 /oklch-color-picker.exe
 /parser_lua_module.*
+*_version


### PR DESCRIPTION
Windows doesn't allow overwriting the library file if it's in use, so it can't be used directly for version checks. Use a separate file instead.